### PR TITLE
Require files for different file sorting on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rvm:
   - 2.1.2
 install:
-  - bundle install --quiet
+  - bundle install
 script:
   - rubocop -fs -D
   - bin/executable-tests-check

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -1,3 +1,5 @@
+require_relative '../files'
+
 module Generator
   module Files
     module MetadataFiles

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -1,4 +1,5 @@
 require 'delegate'
+require_relative 'template_values'
 require_relative 'files/track_files'
 require_relative 'files/metadata_files'
 


### PR DESCRIPTION
Hi there!

When trying to help debug the warnings (and lack thereof locally), I wasn't able to run the tests.

After some digging, I found out it was because some of the generator files were being loaded before some of their dependencies. After adding these two `require_relative`s, the problem was fixed.

Maybe this is a difference between windows / linux and macOS?