### PR TITLE
Fix pig-latin solution

### DIFF
--- a/exercises/pig-latin/.meta/solutions/pig_latin.rb
+++ b/exercises/pig-latin/.meta/solutions/pig_latin.rb
@@ -24,7 +24,7 @@ class PigLatin
   end
 
   def parse_initial_consonant_sound_and_remainder
-    word.scan(/\A([^aeiou]?qu|[^aeiou]+)(.*)/).first
+    word.scan(/\A([^aeiou]?qu|[^aeiou]+(?=y)|[^aeiou]+)(.*)/).first
   end
 end
 


### PR DESCRIPTION
Update regex to look ahead and break starting consonant group on 'y'

Resolves https://github.com/exercism/ruby/issues/750